### PR TITLE
Set path throws error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function _set(key, val, tgt) {
             Vue.set(tgt, path[i], {});
         }
 
-        tgt = tgt[i];
+        tgt = tgt[path[i]];
     }
 
     if (_isObj(tgt[key]) && _isObj(val)) {


### PR DESCRIPTION
I try to set a value to a nested key `field.value` in an empty product.

``` js
const data = {}
_dot.set('field.value', 'The value', data);
```

Results in 
```
[Vue warn]: Error in event handler for "input": "TypeError: Cannot read property 'value' of undefined"
```

The key from the path array was used on the target data instead of the path key as in the get method