### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,13 @@ function _set(key, val, tgt) {
         if (!tgt[path[i]]) {
             Vue.set(tgt, path[i], {});
         }
+        
+        if (isPrototypePolluted(path[i]))
+            continue;
 
         tgt = tgt[path[i]];
     }
-
+    
     if (_isObj(tgt[key]) && _isObj(val)) {
         _merge(tgt[key], val);
 
@@ -80,6 +83,15 @@ function _get(key, tgt) {
     }
 
     return tgt;
+}
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * 
+ * @param string key 
+ */
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports = {


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/vue-dot/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/@websanova/vue-dot/1/README.md

### User Comments:

### :bar_chart: Metadata *

`@websanova/vue-dot` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40websanova%2Fvue-dot

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var dot = require('@websanova/vue-dot');
var obj = {}
console.log("Before : " + {}.polluted);
dot.set("__proto__.polluted","Yes! Its Polluted",obj);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @websanova/vue-dot # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104121260-e5aaab80-5362-11eb-9327-f35b58f1b4a7.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
